### PR TITLE
Enable links on commits to github and bitbucket revision and compare views

### DIFF
--- a/git-slack-hook
+++ b/git-slack-hook
@@ -139,7 +139,7 @@ function notify() {
 
   case ${change_type} in
     "create")
-      header="New ${refname_type} *${short_refname}* has been created in ${repoprefix}"
+      header="New ${refname_type} *${short_refname}* has been created in *${repoprefix}*"
       single_commit_suffix="commit"
       ;;
     "delete")
@@ -175,7 +175,7 @@ function notify() {
         fi
         header_commit_prefix="<${bb_rev_url}|${header_commit_prefix}>"
       fi
-      header="${header_commit_prefix} *pushed* to *${short_refname}* in ${repoprefix}"
+      header="${header_commit_prefix} pushed to *${short_refname}* in *${repoprefix}*"
 
       ;;
     *)
@@ -201,13 +201,13 @@ function notify() {
         repopath=`echo $PWD | cut -c$idx-`
 
         urlformat=`echo $urlpattern | sed "s|%repo_path%|$repopath|g" | sed "s/%rev_hash%/%H/g"`
-      elif [ -n "$ghrepo" ]; then
-        urlformat="https://github.com/$ghrepo/commit/%H"
-      elif [ -n "$bbrepo" ]; then
-        urlformat="https://bitbucket.org/$bbrepo/commits/%H"
       else
-        echo >&2 "$PWD is not in $reporoot and there are no GitHub or BitBucket repository configured. Not creating hyperlinks."
+        echo >&2 "$PWD is not in $reporoot. Not creating hyperlinks."
       fi
+    elif [ -n "$ghrepo" ]; then
+	  urlformat="https://github.com/$ghrepo/commit/%H"
+    elif [ -n "$bbrepo" ]; then
+	  urlformat="https://bitbucket.org/$bbrepo/commits/%H"
     fi
 
     formattedurl=""


### PR DESCRIPTION
This change enables you to link to a repository in either GitHub or BitBucket, to view the changes there. 

When a single commit is pushed, the link will show you that one commit. 
When multiple commits are made, the link will send you to the compare view.

You can enable this by optionally setting:
`git config hooks.slack.github-repo 'myname/my-repo` OR
`git config hooks.slack.bitbucket-repo 'myname/my-repo`

for example, set it to: 
`git config hooks.slack.github-repo 'chriseldredge/git-slack-hook`
to generate links to 
`https://github.com/chriseldredge/git-slack-hook/commit/[hash]`

The result will be:

![image](https://cloud.githubusercontent.com/assets/1104561/3904027/9ec2476c-22d3-11e4-8f8c-d7f1dabb9a8c.png)
