### PR TITLE
Fix broken multiline commit messages and multiple commits

### DIFF
--- a/git-slack-hook
+++ b/git-slack-hook
@@ -242,16 +242,17 @@ function notify() {
       commitformat="%s"
     fi
 
-    # Process the log and escape double quotes; assuming for now that committer names don't have five semicolons in them
-    log_out=$( git log --pretty=format:"%cN;;;;;${formattedurl}${commitformat}" $countarg ${start}..${end} \
-             | sed ':a;N;$!ba;s/\n/\\n/g' \
-             | sed -e 's/\\/\\\\/g' \
-             | sed -e 's/"/\\"/g' \
-             | sed -e 's/\(.*\);;;;;\(.*\)/{"title":"\1","value":"\2","short":false},/' )
+    # Process the log and escape double quotes and backslashes; assuming commit names/messages don't have five of the following: & ; @
+    log_out=$( git log --pretty=format:"&&&&&%cN;;;;;${formattedurl}${commitformat}@@@@@" $countarg ${start}..${end} \
+        | sed ':a;N;$!ba;s/\n+/\\n/g' \
+        | sed -e 's/\\/\\\\/g' \
+        | sed -e 's/"/\\"/g' \
+        | sed -e 's/&&&&&\(.*\);;;;;/{ \"fallback\" : \"\", \"color\" : \"good\", \"fields\" : [{"title":"\1","value":"/g' \
+        | sed -e 's/@@@@@/","short":false},]},/g' \
+        | sed -e 's/,\]/]/' )
 
-    fields=${log_out%?}
+    attachments="[${log_out%?}]"
 
-    attachments="[{ \"fallback\" : \"${header}\", \"color\" : \"good\", \"fields\" : [${fields}]}]"
   fi
 
   if [ -n "${attachments}" ] && [[ "${attachments}" != "" ]]; then


### PR DESCRIPTION
This commit fixes both multiple commits not showing up properly, and also allows for multiple lines in a commit messages (even if grouped with multiple commits).

Changed the format of the `git log` so that two replacements could be made - this was instead of some huge `sed` script or using other tools like Perl, to keep things simple.

Tested with 1 commit single and multiline messages, and multiple commits with both single and multiline messages.

Fixes #20 and #24, simplifies the solution proposed by pull request #26 - indeed with this, #26 wouldn't be needed and as mentioned on the comments page for that pull request it doesn't work for multiline messages.

Would appreciate feedback!