### PR TITLE
Fix malformed payload when bundeling multiple commits

### DIFF
--- a/git-slack-hook
+++ b/git-slack-hook
@@ -247,7 +247,7 @@ function notify() {
         | perl -p -e 's/@@@@@\n+/@@@@@/mg' \
         | sed -e 's/\\/\\\\/g' \
         | sed -e 's/"/\\"/g' \
-        | sed -e 's/&&&&&\(.*\);;;;;/{ \"fallback\" : \"\", \"color\" : \"good\", \"fields\" : [{"title":"\1","value":"/g' \
+        | sed -e 's/&&&&&\([^;]*\);;;;;/{ "fallback" : "", "color" : "good", "fields" : [{"title":"\1","value":"/g' \
         | sed -e 's/@@@@@/","short":false},]},/g' \
         | sed -e 's/,\]/]/' )
 


### PR DESCRIPTION
reference to #24 as #27 is not fixing it (using gitweb)
resolves the greedy regex to produce `","short":false}]},&&&&&Tabakhase","value":`

(using negative look-around would be cleaner, but does not seem to work there)