### PR TITLE
Escapes for various elements (urls, json, slack payload, directories, commit log contents)

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+
+(sh-mode . ((indent-tabs-mode . nil)
+	    (sh-basic-offset . 2)))
+

--- a/git-slack-hook
+++ b/git-slack-hook
@@ -56,7 +56,7 @@ function notify() {
   fi
 
   # --- Get the revision types
-  newrev_type=$(git cat-file -t $newrev 2> /dev/null)
+  newrev_type=$(git cat-file -t "$newrev" 2> /dev/null)
   oldrev_type=$(git cat-file -t "$oldrev" 2> /dev/null)
   case "$change_type" in
     create|update)

--- a/git-slack-hook
+++ b/git-slack-hook
@@ -126,13 +126,13 @@ function notify() {
   # Repo name, either Gitolite or normal repo.
   if [ -n "$GL_REPO" ]; then
     # it's a gitolite repo
-    repodir=$(basename $(pwd))
+    repodir=$(basename "$(pwd)")
     repo=$GL_REPO
   else
-    repodir=$(basename $(pwd))
+    repodir=$(basename "$(pwd)")
     if [ "$repodir" == ".git" ]; then
-      repodir=$(dirname $PWD)
-      repodir=$(basename $repodir)
+      repodir=$(dirname "$PWD")
+      repodir=$(basename "$repodir")
     fi
     repo=${repodir%.git}
   fi

--- a/git-slack-hook
+++ b/git-slack-hook
@@ -31,7 +31,52 @@ function help() {
 }
 
 function replace_variables() {
-	sed "s|%repo_path%|$repopath|g;s|%old_rev_hash%|$oldrev|g;s|%new_rev_hash%|$newrev|g;s|%rev_hash%|$newrev|g;s|%repo_prefix%|$repoprefix|g"
+  sed "s|%repo_path%|$repopath|g;s|%old_rev_hash%|$oldrev|g;s|%new_rev_hash%|$newrev|g;s|%rev_hash%|$newrev|g;s|%repo_prefix%|$repoprefix|g"
+}
+
+
+function json_string() {
+  # takes care of special characters and unicode escapes. assumes
+  # input is utf-8 (in practice, every commit message may have a
+  # different encoding). invalid utf-8 sequences are replaced
+  # ("\ufffd" or "\u00XX" depending on input).
+  python -c "import sys, json; print json.dumps(sys.argv[1].decode('utf-8', 'replace'))" "$1"
+}
+
+function json_join() {
+  local IFS=","
+  echo -n "$*";
+}
+
+function parse_record() {
+  # parse_record STREAMVAR SEPARATOR [FIELDVAR]+
+  #
+  # Works similarly to the `read` builtin. Instead of using IFS, it
+  # splits fields based on the separator given. It reads from and
+  # modifies in place variable named STREAMVAR.  Subsequent parameters
+  # are variable _names_ used to store tokens, in order.
+  #
+  # variable STREAMVAR will be advanced by one record: [<FIELD><SEP>]+[\n]*
+  #
+
+  local -n stream=$1
+  local -n field
+  local sep="$2"
+  local lf=$'\n' #newline
+
+  shift 2
+
+  # field will point to a different field variable in turn
+  for field in "$@"; do
+    field="${stream%%${sep}*}"
+    # advance stream
+    stream="${stream:${#field}}"
+    stream="${stream:${#sep}}"
+  done
+  # eat trailing newlines between records
+  while [[ "${stream:0:1}" == $lf ]]; do
+    stream=${stream:1}
+  done
 }
 
 function notify() {
@@ -192,19 +237,22 @@ function notify() {
 
     urlformat=
     if [ -n "$changeseturlpattern" -a -n "$reporoot" ]; then
-      if [[ $PWD == ${reporoot}* ]]; then
+      if [[ "$PWD" == ${reporoot}* ]]; then
         repopath=$PWD
-        base=$(basename $PWD)
+        base=$(basename "$PWD")
         if [ "$base" == ".git" ]; then
           repopath=$(dirname $repopath)
         fi
-        idx=$(echo $reporoot | wc -c | tr -d ' ')
-        repopath=$(echo $repopath | cut -c$idx-)
-        urlformat=$(echo $changeseturlpattern | replace_variables)
+        idx=$(echo "$reporoot" | wc -c | tr -d ' ')
+        repopath=$(echo "$repopath" | cut -c$idx-)
+        urlformat=$(echo "$changeseturlpattern" | replace_variables)
 
         if [ -n "$compareurlpattern" ]; then
-          comparelink=$(echo $compareurlpattern | replace_variables)
-          header=$(echo $header | sed -e "s|\([a-zA-Z0-9]\{1,\} new commit[s]\{0,1\}\)|\<$comparelink\|\\1\>|")
+          comparelink=$(echo "$compareurlpattern" | replace_variables)
+	  # insert > after 'new commit(s)'.
+	  # we avoid using comparelink on replacement of sed call (because of possible &)
+          header=$(echo "$header" | sed -e "s|\([a-zA-Z0-9]\{1,\} new commit[s]\{0,1\}\)\(.*\)|\\1\>\\2|")
+	  header="<$comparelink|$header"
         fi
       else
         echo >&2 "$PWD is not in $reporoot. Not creating hyperlinks."
@@ -242,27 +290,38 @@ function notify() {
       commitformat="%s"
     fi
 
-    # Process the log and escape double quotes and backslashes; assuming commit names/messages don't have five of the following: & ; @
-    log_out=$( git log --pretty=format:"&&&&&%cN;;;;;${formattedurl}${commitformat}@@@@@" $countarg ${start}..${end} \
-        | perl -p -e 's/@@@@@\n+/@@@@@/mg' \
-        | sed -e 's/\\/\\\\/g' \
-        | sed -e 's/"/\\"/g' \
-        | sed -e 's/&&&&&\(.*\);;;;;/{ \"fallback\" : \"\", \"color\" : \"good\", \"fields\" : [{"title":"\1","value":"/g' \
-        | sed -e 's/@@@@@/","short":false},]},/g' \
-        | sed -e 's/,\]/]/' )
+    sep="boundary-${RANDOM}-${RANDOM}-${RANDOM}-${RANDOM}-${RANDOM}-${RANDOM}-${RANDOM}--"
+    log_out=$(git log --pretty=format:"%cN${sep}${formattedurl}${commitformat}${sep}" $countarg "${start}..${end}")
+    attachment_arr=()
+    while [[ -n "${log_out}" ]]; do
+      title=""
+      value=""
+      parse_record log_out "${sep}" title value
 
-    attachments="[${log_out%?}]"
+      attachment_arr+=('
+{
+  "fallback": "",
+  "color": "good",
+  "fields": [{
+    "title": '"$(json_string "$title")"',
+    "value": '"$(json_string "$value")"',
+    "short": false
+  }]
+}')
+    done
+
 
   fi
 
-  if [ -n "${attachments}" ] && [[ "${attachments}" != "" ]]; then
-    msg=$(echo -e "\"text\":\"${header}\", \"attachments\" : $attachments")
+  if [[ "${#attachment_arr[@]}" -gt 0 ]]; then
+    attachments="[ $( json_join "${attachment_arr[@]}" ) ]"
+    msg='
+"text": '"$(json_string "$header")"',
+"attachments": '"$attachments"
   else
-    msg=$(echo -e "\"text\":\"${header}\"")
+    msg='
+"text": '"$(json_string "${header}")"
   fi
-
-  # slack API uses \n substitution for newlines
-  msg=$(echo -n "${msg}" | perl -p -e 's/\n/\\n/mg')
 
   webhook_url=$(git config --get hooks.slack.webhook-url)
   channel=$(git config --get hooks.slack.channel)
@@ -278,21 +337,12 @@ function notify() {
 
   payload="{${msg}"
 
-  if [ -n "$channel" ]; then
-    payload="$payload, \"channel\": \"$channel\""
-  fi
+  [[ -z "$channel" ]]   || payload+=',"channel":'"$(json_string "$channel")"
+  [[ -z "$username" ]]  || payload+=',"username":'"$(json_string "$username")"
+  [[ -z "$iconurl" ]]   || payload+=',"icon_url":'"$(json_string "$iconurl")"
+  [[ -z "$iconemoji" ]] || payload+=',"icon_emoji":'"$(json_string "$iconemoji")"
 
-  if [ -n "$username" ]; then
-    payload="$payload, \"username\": \"$username\""
-  fi
-
-  if [ -n "$iconurl" ]; then
-    payload="$payload, \"icon_url\": \"$iconurl\""
-  elif [ -n "$iconemoji" ]; then
-    payload="$payload, \"icon_emoji\": \"$iconemoji\""
-  fi
-
-  payload="$payload}"
+  payload+="}"
 
   if [ -n "$DEBUG" ]; then
     echo "POST $webhook_url"

--- a/git-slack-hook
+++ b/git-slack-hook
@@ -351,7 +351,7 @@ function notify() {
   fi
 
   curl -s \
-      -d "payload=$payload" \
+      --data-urlencode "payload=$payload" \
       "$webhook_url" \
       >/dev/null
 


### PR DESCRIPTION
This pull request is concerned with escaping and encoding fixes. I've uncovered several problems, trying to set hooks for a cGit web viewer on a gitolite repository system.

1.  Parsing the logs (esp. multiple update changesets):

   - don't use sed for splitting fields. sed doesn't support non-greedy wildcards. this is problematic for sed forms such as `'s/foo\(.*\)bar/\1/g'`. any "bar" substring would get gobbed up in the group. Alternatives to make the grouping non-greedy, such as [^x]*, introduce ambiguities and negative lookaheads are difficult to maintain. This is an improved version of pull request #36 , #27 (which didn't fix the issue completely).

   - The patches here replaces the shell pipeline with a bash tokenizer and a nonce as the field separator. The random separator makes false positives extremely unlikely, the code is easy to read, and the template straightforward to extend.

   - The fields `title` and `value` are first extracted, and then inserted into a json string. The previous shell pipeline conflated the two tasks. The resulting code is much easier to extend.

1. Unsupported characters in URLs:

   - `sed "s/%hash%/$url/g"` produces unexpected results without escaping `$url` for special sed-interpreted character commands (like '&'). For these forms, the patch provides workarounds that avoid the need to escape URLs -- but produce the same output.

   - ampersand '&' characters are valid URL query string parameters, eg. ?a=b&c=d . the Cgit git viewer uses these forms to display commits ( `?id=abcabc&id2=defdef` ). These query strings wreak havoc on the sed substitutions. Users shouldn't have to escape URLs in their config. Fixes issue #24. 

1. Directory path problems:

   - git repo directory names with spaces produce invalid notification messages. the patch provides adequate shell quoting during repo name determination: instances of `$(basename $foo)` are changed to `$(basename "$foo")`.

1. JSON encoding problems:

   - Only a subset of special characters were escaped (linefeeds 0x0a, '\', and '"') in json strings. Unicode characters should be escaped too. The patch uses a python one-liner to properly escape json (with the json package). It assumes the commit messages from the log are utf-8. Invalid sequences are replaced with unicode replacement char json sequences `\ufffd`.

   - A comment seemed to indicate that slack did not support newlines in the payload. This is erroneous. The json may contain linefeeds, but they must be escaped inside json string literals.

   - the channel name, emoji, and other string fields of the payload are now also json-encoded.

1. POST body encoding fixes.

  - The content passed to `curl -d` is assumed to be already encoded. the patch uses `--data-urlencode` instead to ask curl to perform url encoding. This bit of the patch resolves issue #38  and #28. 

1. Things not covered: if the commit messages contain <http://example.com|b> sequences, those aren't escaped for slack.