### PR TITLE
A better fix for dealing with symlinks in repos-root path

### DIFF
--- a/git-slack-hook
+++ b/git-slack-hook
@@ -190,6 +190,11 @@ function notify() {
     compareurlpattern=$(git config --get hooks.slack.compare-url-pattern)
     reporoot=$(git config --get hooks.slack.repos-root)
 
+    if [ -n "$reporoot" ]; then
+      # Get absolute path
+      reporoot=$(readlink -f $reporoot)
+    fi
+
     urlformat=
     if [ -n "$changeseturlpattern" -a -n "$reporoot" ]; then
       if [[ $PWD == ${reporoot}* ]]; then


### PR DESCRIPTION
This one doesn't fail for people that don't have repos-root set