### PR TITLE
Fixed multiple commits not getting converted to JSON

### DIFF
--- a/git-slack-hook
+++ b/git-slack-hook
@@ -252,7 +252,7 @@ function notify() {
         | perl -p -e 's/@@@@@\n+/@@@@@/mg' \
         | sed -e 's/\\/\\\\/g' \
         | sed -e 's/"/\\"/g' \
-        | sed -e 's/&&&&&\(.*\);;;;;/{ \"fallback\" : \"\", \"color\" : \"good\", \"fields\" : [{"title":"\1","value":"/g' \
+        | perl -p -e 's/&&&&&(.*?);;;;;/{ \"fallback\" : \"\", \"color\" : \"good\", \"fields\" : [{"title":"\1","value":"/g' \
         | sed -e 's/@@@@@/","short":false},]},/g' \
         | sed -e 's/,\]/]/' )
 


### PR DESCRIPTION
sed was greedily matching and resulting in invalid JSON, which caused the hook to not work when setting hooks.slack.show-only-last-commit to true.

Using `perl -p -e` with a nongreedy regex to match &&&&& and ;;;;; fixed the problem.